### PR TITLE
Use 'translatable' instead of 'columns' in foreach loop

### DIFF
--- a/public_html/backend/apps/translations/translations.inc.php
+++ b/public_html/backend/apps/translations/translations.inc.php
@@ -147,8 +147,9 @@
 	};
 
 	foreach ($collections as $collection) {
+		if (empty($collection['translatable'])) continue;
 		if (empty($_GET['collections']) || in_array($collection['id'], $_GET['collections'])) {
-			foreach ($collection['columns'] as $column) {
+			foreach ($collection['translatable'] as $column) {
 				$sql_union[] = $union_select($collection['id'], $collection['entity'], $column);
 			}
 		}


### PR DESCRIPTION
To fix these errors:
⚠️ Warning:  Undefined array key "columns"  in app://backend/apps/translations/translations.inc.php on line 151 Backtrace:
 ↪ app://includes/entities/ent_view.inc.php on line 175 in include()
 ↪ app://includes/entities/ent_view.inc.php on line 177 in {closure:ent_view::render():172}()
 ↪ app://includes/entities/ent_view.inc.php on line 133 in render()
 ↪ app://backend/pages/index.inc.php on line 56 in __toString()
 ↪ app://includes/nodes/nod_route.inc.php on line 205 in include()
 ↪ app://includes/nodes/nod_route.inc.php on line 206 in {closure:route::process():204}()
 ↪ app://index.php on line 72 in process()
Request: GET /admin/translations/translations HTTP/1.1 Platform: LiteCore/1.0.0

Solution pulled from LC3, so it should be correct.