### PR TITLE
Add case for 'string' in settings processing

### DIFF
--- a/public_html/backend/apps/settings/settings.inc.php
+++ b/public_html/backend/apps/settings/settings.inc.php
@@ -45,6 +45,7 @@
 						break;
 
 					case 'json':
+					case 'string':
 						$value = (string)$_POST['settings'][$key];
 						break;
 


### PR DESCRIPTION
⚠️ Warning:  Undefined variable $value  in app://backend/apps/settings/settings.inc.php on line 62 Backtrace:
 ↪ app://includes/entities/ent_view.inc.php on line 175 in include()
 ↪ app://includes/entities/ent_view.inc.php on line 177 in {closure:ent_view::render():172}()
 ↪ app://includes/entities/ent_view.inc.php on line 133 in render()
 ↪ app://backend/pages/index.inc.php on line 56 in __toString()
 ↪ app://includes/nodes/nod_route.inc.php on line 205 in include()
 ↪ app://includes/nodes/nod_route.inc.php on line 206 in {closure:route::process():204}()
 ↪ app://index.php on line 72 in process()
Request: POST /admin/settings/site_info?page=1&action=edit&key=site_email HTTP/1.1 Platform: LiteCore/1.0.0