### PR TITLE
Update settings.inc.php...

### DIFF
--- a/public_html/backend/apps/settings/settings.inc.php
+++ b/public_html/backend/apps/settings/settings.inc.php
@@ -121,7 +121,7 @@
 
 			case (preg_match('#^regional_#', $setting['function'])):
 				$setting['value'] = !empty($setting['value']) ? json_decode($setting['value'], true) : [];
-				$setting['display_value'] = isset($setting['value'][language::$selected['code']]) ? $setting['value'][language::$selected['code']] : null;
+				$setting['display_value'] = isset($setting['value'][language::$selected['code']]) ? $setting['value'][language::$selected['code']] : '';
 				break;
 
 				case (preg_match('#^toggle$#', $setting['function'])):


### PR DESCRIPTION
to stop this error:
```
 ℹ️ Deprecated:  nl2br(): Passing null to parameter #1 ($string) of type string is deprecated  in app://backend/apps/settings/settings.inc.php on line 227
Backtrace:
 ↪ app://backend/apps/settings/settings.inc.php on line 227 in nl2br()
 ↪ app://includes/entities/ent_view.inc.php on line 175 in include()
 ↪ app://includes/entities/ent_view.inc.php on line 177 in {closure:ent_view::render():172}()
 ↪ app://includes/entities/ent_view.inc.php on line 133 in render()
 ↪ app://backend/pages/index.inc.php on line 56 in __toString()
 ↪ app://includes/nodes/nod_route.inc.php on line 205 in include()
 ↪ app://includes/nodes/nod_route.inc.php on line 206 in {closure:route::process():204}()
 ↪ app://index.php on line 72 in process()
Request: GET /admin/settings/listings HTTP/1.1
Platform: LiteCore/1.0.0
```
Not sure if the fix is correct, but it stops the error.